### PR TITLE
Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ composer require gepo/apns-http2
 
 ## AAA Certificate
 
-Since 29 March 2021, the AAA certificate is required. You can get it here: https://support.sectigo.com/Com_KnowledgeDetailPage?Id=kA03l00000117cL (the first one, name AAA).
+Since 29 March 2021, the AAA certificate is required. You can read about it and get it here: https://developer.apple.com/news/?id=7gx0a2lp.
 
 On Ubuntu, you must put it in `/usr/local/share/ca-certificates/extra` (create the path if it doesn't exist), and run `update-ca-certificates` as `root`).
 
@@ -83,6 +83,7 @@ require_once __DIR__ . '/vendor/autoload.php';
 
 use Apns\Client as ApnsClient;
 use Apns\Message as ApnsMessage;
+use ApnsException;
 
 $token = 'a00915e74d60d71ba3fb80252a5e197b60f2e7743f61b4411c713e9aabd2854f';
 
@@ -119,7 +120,7 @@ $message = (new ApnsMessage())
 // Send it and catch errors
 try {
     $client->send($message);
-} catch (\Exception $e) {
+} catch (ApnsException $e) {
     // https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CommunicatingwithAPNs.html#//apple_ref/doc/uid/TP40008194-CH11-SW17
     switch ($e->getMessage()) {
         case 'BadDeviceToken':

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ brew reinstall php56 --with-homebrew-curl
 
 require_once __DIR__ . '/vendor/autoload.php';
 
-$client = new \Apns\Client(__DIR__ . '/certs/apns-prod-cert.pem', true); // true is for sandbox
+$client = new \Apns\Client(__DIR__ . '/certs/apns-dev-cert.pem', true); // true is for sandbox
 
 $message = (new \Apns\Message())
     ->setDeviceIdentifier('a00915e74d60d71ba3fb80252a5e197b60f2e7743f61b4411c713e9aabd2854f')
@@ -95,7 +95,7 @@ if ((!ctype_xdigit($token)) || (64 != strlen($token))) {
 // Create client with production certificate and passphrase
 $client = new ApnsClient(
     [
-        __DIR__ . '/certs/apns-dev-cert.pem',
+        __DIR__ . '/certs/apns-prod-cert.pem',
         'my-passphrase'
     ], 
     false // false is for production

--- a/README.md
+++ b/README.md
@@ -10,7 +10,42 @@ PHP library for sending notifications via Apple Push Notification service (APNS)
 
 # Installation
 
-You need curl with http2 support installed on your system before work.
+```
+composer require gepo/apns-http2
+```
+
+# Requirements
+
+## AAA Certificate
+
+Since 29 March 2021, the AAA certificate is required. You can get it here: https://support.sectigo.com/Com_KnowledgeDetailPage?Id=kA03l00000117cL (the first one, name AAA).
+
+On Ubuntu, you must put it in `/usr/local/share/ca-certificates/extra` (create the path if it doesn't exist), and run `update-ca-certificates` as `root`).
+
+## cURL HTTP/2 support
+
+You need cURL with HTTP/2 support installed on your system before work.
+
+### Check if your installation supports it
+
+Here's a simple script to check if your installation supports cURL with HTTP/2:
+
+```php
+<?php
+
+if (!defined('CURL_HTTP_VERSION_2_0')) {
+        define('CURL_HTTP_VERSION_2_0', 3);
+}
+
+$version = curl_version();
+if ($version['features'] & constant('CURL_VERSION_HTTP2') !== 0) {
+        echo 'HTTP/2 supported'.PHP_EOL;
+} else {
+        echo 'HTTP/2 not supported'.PHP_EOL;
+}
+```
+
+### Installation on MacOS
 
 To install it on OS X:
 ```
@@ -19,24 +54,105 @@ brew link curl --force
 brew reinstall php56 --with-homebrew-curl
 ```
 
- 
-```
-composer require gepo/apns-http2
-```
-
 # Usage
+
+## Simple
 
 ```php
 <?php
 
 require_once __DIR__ . '/vendor/autoload.php';
 
-$client = new \Apns\Client(__DIR__ . '/certs/apns-dev-cert.pem', true);
+$client = new \Apns\Client(__DIR__ . '/certs/apns-prod-cert.pem', true); // true is for sandbox
 
 $message = (new \Apns\Message())
     ->setDeviceIdentifier('a00915e74d60d71ba3fb80252a5e197b60f2e7743f61b4411c713e9aabd2854f')
     ->setAlert('Test message')
+    ->setTopic('com.mycompany.myapp')
 ;
 
 $client->send($message);
+```
+
+## Complex
+
+```php
+<?php
+
+require_once __DIR__ . '/vendor/autoload.php';
+
+use Apns\Client as ApnsClient;
+use Apns\Message as ApnsMessage;
+
+$token = 'a00915e74d60d71ba3fb80252a5e197b60f2e7743f61b4411c713e9aabd2854f';
+
+// Check if token format is valid
+if ((!ctype_xdigit($token)) || (64 != strlen($token))) {
+   die('Token is invalid!');
+}
+
+// Create client with production certificate and passphrase
+$client = new ApnsClient(
+    [
+        __DIR__ . '/certs/apns-dev-cert.pem',
+        'my-passphrase'
+    ], 
+    false // false is for production
+);
+
+// Get topic from certificate file
+if ($cert = openssl_x509_parse(file_get_contents($apnsClient->getSslCert()[0]))) {
+    $topic = $cert['subject']['UID'];
+}
+
+// Create message
+$message = (new ApnsMessage())
+    ->setDeviceIdentifier($token)
+    ->setAlert('This is a test message sent on '.gmdate('r'))
+    ->setData([
+        'Key1' => 'Value1',
+        'Key2' => 'Value2',
+        'Key3' => 'Value3',
+    ])
+    ->setTopic($topic);
+
+// Send it and catch errors
+try {
+    $client->send($message);
+} catch (\Exception $e) {
+    // https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CommunicatingwithAPNs.html#//apple_ref/doc/uid/TP40008194-CH11-SW17
+    switch ($e->getMessage()) {
+        case 'BadDeviceToken':
+        case 'ExpiredProviderToken':
+        case 'InvalidProviderToken':
+        case 'MissingProviderToken':
+        case 'Unregistered':
+            // do something, ie. remove the token from your list
+            break;
+        case 'BadCollapseId':
+        case 'BadExpirationDate':
+        case 'BadMessageId':
+        case 'BadPriority':
+            // do something, ie. check your parameters
+            break;
+        case 'BadTopic':
+        case 'MissingTopic':
+        case 'DeviceTokenNotForTopic':
+            // do something, ie. check that your topic is ok
+            break;
+        case 'BadCertificate':
+            // do something, ie. check the certificate you provided
+            break;
+        case 'BadCertificateEnvironment':
+            // do something, ie. check your certificate/environment (sandbox or production)
+            break;
+        case 'TooManyRequests':
+        case 'TooManyProviderTokenUpdates':
+            // do something, ie. throttle your requests
+            break;
+        default:
+            // do something
+            break;
+    }
+} 
 ```


### PR DESCRIPTION
* Added test for HTTP/2 support in cURL
* Added info on how to find and install the AAA certificate required from March 29, 2021
* Added the topic to the simple example
* Added a more complex example, with token format validation, topic discovery, and sample error detection/handling