### PR TITLE
Chores: Upgrade to PHPUnit8; Fix Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,13 @@
-dist: trusty
+dist: xenial
 sudo: false
 
 language: php
 
 php:
-  - 5.6
-  - 7.0
-  - hhvm
+  - 7.4
+  - 8.0
+  - 7.3
+  - 7.2
 
 matrix:
  allow_failures:

--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ composer require gepo/apns-http2
 
 Since 29 March 2021, the AAA certificate is required. You can read about it and get it here: https://developer.apple.com/news/?id=7gx0a2lp.
 
-On Ubuntu, you must put it in `/usr/local/share/ca-certificates/extra` (create the path if it doesn't exist), and run `update-ca-certificates` as `root`).
+On Ubuntu, you must put it in `/usr/local/share/ca-certificates/extra/` (create the path if it doesn't exist), and run `update-ca-certificates` as `root`).
 
 ## cURL HTTP/2 support
 
-You need cURL with HTTP/2 support installed on your system before work.
+You need cURL with HTTP/2 support installed on your system for this library to work.
 
 ### Check if your installation supports it
 
@@ -45,9 +45,9 @@ if ($version['features'] & constant('CURL_VERSION_HTTP2') !== 0) {
 }
 ```
 
-### Installation on MacOS
+### Installation on MacOS X
 
-To install it on OS X:
+To install it on OS X with Homebrew (the example is for php56):
 ```
 brew install curl --with-nghttp2 --with-openssl
 brew link curl --force
@@ -83,7 +83,7 @@ require_once __DIR__ . '/vendor/autoload.php';
 
 use Apns\Client as ApnsClient;
 use Apns\Message as ApnsMessage;
-use ApnsException;
+use Apns\Exception\ApnsException;
 
 $token = 'a00915e74d60d71ba3fb80252a5e197b60f2e7743f61b4411c713e9aabd2854f';
 

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,6 @@
         "guzzlehttp/guzzle": "6.*"
     },
     "require-dev": {
-        "phpunit/phpunit": "~6.3"
+        "phpunit/phpunit": "~8.5"
     }
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -9,7 +9,7 @@ class ClientTest extends TestCase
     public function testCreateSandbox()
     {
         $client = new Client('', true);
-        $this->assertContains('development', $client->getServer());
+        $this->assertStringContainsString('development', $client->getServer());
     }
 
     /**
@@ -32,7 +32,7 @@ class ClientTest extends TestCase
     public function testCreateProd()
     {
         $client = new Client('', false);
-        $this->assertNotContains('develop', $client->getServer());
+        $this->assertStringNotContainsString('develop', $client->getServer());
     }
 
     public function testCreatePushURI()
@@ -40,8 +40,8 @@ class ClientTest extends TestCase
         $client = new Client('', true);
         $pushUri = $client->getPushURI((new Message())->setDeviceIdentifier('foobar'));
 
-        $this->assertContains('develop', $pushUri);
-        $this->assertContains('foobar', $pushUri);
+        $this->assertStringContainsString('develop', $pushUri);
+        $this->assertStringContainsString('foobar', $pushUri);
     }
 
     public function testSend()
@@ -60,6 +60,6 @@ class ClientTest extends TestCase
      */
     private function getMockCallable()
     {
-        return $this->getMockBuilder('object')->setMethods(['__invoke'])->getMock();
+        return $this->getMockBuilder('stdClass')->setMethods(['__invoke'])->getMock();
     }
 }

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -101,11 +101,9 @@ class MessageTest extends TestCase
         $this->assertEquals(['aps' => ['alert' => ['body' => 'foo']]], $this->serialized($msg));
     }
 
-    /**
-     * @expectedException \Exception
-     */
     public function testSetInvalidAlert()
     {
+        $this->expectException(\Exception::class);
         $msg = new Message();
         $msg->setAlert(new \stdClass());
     }
@@ -126,21 +124,17 @@ class MessageTest extends TestCase
         $this->assertEquals(['aps' => [], 'foo' => 'bar'], $this->serialized($msg));
     }
 
-    /**
-     * @expectedException  \Exception
-     */
     public function testSetCustomDataInvalidKey()
     {
+        $this->expectException(\Exception::class);
         $msg = new Message();
         $msg->addCustomData('aps', 'foo');
     }
 
-    /**
-     * @expectedException  \Exception
-     * @expectedExceptionMessage DateTime
-     */
     public function testSetCustomDataInvalidObject()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('DateTime');
         $msg = new Message();
         $msg->addCustomData('foo', new \DateTime);
     }


### PR DESCRIPTION
- Upgraded to PHPUnit 8 to be able to test with PHP 8.0
- Dropped Travis tests for PHP 5.6, 7.0 and 7.1; reason: not compatible with PHPUnit 8
- Fixed a few minor things in the README
- Upgraded Travis' distribution to Xenial (it's been their new default for a good while now)